### PR TITLE
chore: updates actions v3 > v4

### DIFF
--- a/.github/workflows/pr-close-signal.yaml
+++ b/.github/workflows/pr-close-signal.yaml
@@ -16,8 +16,7 @@ jobs:
           mkdir -p ./pr
           printf ${{ github.event.number }} > ./pr/NUM
       - name: Upload Diff
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: ./pr
-

--- a/.github/workflows/pr-receive.yaml
+++ b/.github/workflows/pr-receive.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: "Upload PR number"
         id: upload
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: ${{ github.workspace }}/NR
@@ -58,10 +58,10 @@ jobs:
       MD: ${{ github.workspace }}/site/built
     steps:
       - name: "Check Out Main Branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Check Out Staging Branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: md-outputs
           path: ${{ env.MD }}
@@ -107,20 +107,20 @@ jobs:
         shell: Rscript {0}
 
       - name: "Upload PR"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: ${{ env.PR }}
 
       - name: "Upload Diff"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: diff
           path: ${{ env.CHIVE }}
           retention-days: 1
 
       - name: "Upload Build"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: built
           path: ${{ env.MD }}


### PR DESCRIPTION
Closes #57

I've also added a Personal Access Token as required to automatically update the workflows although confusingly this
action was already running successfully even though there were no tokens stored in the account (security issue?).